### PR TITLE
Closes #9 | Change id filter on card.js into dataloader name

### DIFF
--- a/card.js
+++ b/card.js
@@ -31,7 +31,7 @@ axios.get(url, ).then(function(response) {
         let headers = []
 
         // If you disable display name don't remove it from "headersWhiteList" becuase we use this as index key to push subsets to his row 
-        let headersWhiteList = ['Name','Link', 'HF Link', 'Year', 'Volume', 'Unit', 'Paper Title', 'Paper Link', 'Access', 'Tasks', 'License', 'Language', 'Dialect', 'Domain', 'Form', 'Collection Style', 'Ethical Risks', 'Provider', 'Derived From', 'Test Split', 'Subsets']
+        let headersWhiteList = ['Name','Link', 'HF Link', 'Year', 'Volume', 'Unit', 'Paper Title', 'Paper Link', 'Access', 'Tasks', 'License', 'Language', 'Dialect', 'Domain', 'Form', 'Collection Style', 'Ethical Risks', 'Provider', 'Derived From', 'Test Split', 'Notes', 'Dataloader']
         
         $('.loading-spinner').hide()
 
@@ -52,10 +52,8 @@ axios.get(url, ).then(function(response) {
             }
         })
 
-        console.log(rowData)
-
         let subsets = []
-        rowData.filter(row => row.values[0].formattedValue == idx).forEach((row, rowIndex) => {
+        rowData.filter(row => row.values[row.values.length-1].formattedValue == idx).forEach((row, rowIndex) => {
             console.log(row)
             subsets.push(row.values)
         })
@@ -97,6 +95,8 @@ axios.get(url, ).then(function(response) {
                 link = value;
             } else if (element == 'Paper Title') {
                 paper_title = value;
+            } else if (element == 'Dataloader'){
+                // Skip
             } else {
                 dataset.push({
                     0: element,

--- a/index.html
+++ b/index.html
@@ -90,38 +90,6 @@
         </div>
       </section>
       <!-- END Table Section -->
-
-      <!-- collabrate section -->
-      <!-- <section class="py-md-0 pb-3 bg-warning-gradient">
-        <div class="container">
-          <div class="row flex-center">
-            <div class="col-md-5">
-              <img
-                class="w-100 w-lg-75 d-none d-md-block"
-                src="assets/images/branding-image.png"
-                width="320"
-                alt="Image that contain the logo of arbML"
-              />
-            </div>
-            <div class="col-md-1"></div>
-            <div class="col-md-6">
-              <h1 class="fw-bold fs-4 fs-lg-5 fs-xl-6 mb-4 text-primary">
-                Collaborate with the<br class="d-none d-xl-block" />team
-              </h1>
-              <a
-                class="btn btn-lg hover btn-gradient"
-                href="https://github.com/IndoNLP/nusantara-datasets/edit/master/README.md"
-                >Github</a
-              >
-              <a
-                class="btn btn-lg hover btn-gradient"
-                href="https://chat.whatsapp.com/Jn4nM6l3kSn3p4kJVESTwv"
-                >Community Channels</a
-              >
-            </div>
-          </div>
-        </div>
-      </section> -->
     </main>
     
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>

--- a/index.js
+++ b/index.js
@@ -127,6 +127,7 @@ axios.get(url, {
 
 
         previous_id = -1
+        console.log('headers_dict' + JSON. stringify(headers_dict));
         for (let index = 0; index < rows.length; index++) {
             const row = rows[index];
             const hf_link = row[headers_dict['HF Link']].formattedValue ? row[headers_dict['HF Link']].formattedValue : ''
@@ -134,8 +135,7 @@ axios.get(url, {
             const data_icon = data_link.includes("github") ? "github" : "download"
             const pr_text = row[headers_dict['Paper Title']].formattedValue ? row[headers_dict['Paper Title']].formattedValue : ''
             const pr_link = row[headers_dict['Paper Link']].formattedValue ? row[headers_dict['Paper Link']].formattedValue : ''
-            
-           
+            const loader_name = row[headers_dict['Dataloader']].formattedValue ? row[headers_dict['Dataloader']].formattedValue : ''
 
             let id = row[headers[0].index].formattedValue
             
@@ -144,7 +144,7 @@ axios.get(url, {
             } else {
                 dataset.push({
                     0: row[headers[0].index].formattedValue,
-                    1: linkuize(row[headers[1].index].formattedValue, `card.html?${id}`),
+                    1: linkuize(row[headers[1].index].formattedValue, `card.html?${loader_name}`),
                     2: (data_link.includes("https") ? linkuize(getIcon(data_icon),  data_link) : "") +  
                        (hf_link.includes("huggingface") ? linkuize(getIcon('hf'), hf_link) : ""),
                     3: row[headers[3].index].formattedValue ? row[headers[3].index].formattedValue : '',


### PR DESCRIPTION
- Change the url link in `index.js` from passing `<url>?id` into `<url>?id`
- Update url handling on the `card.js` to retrieve the data by dataloader name instead of id 

As an example, this URL for CASA: `https://indonlp.github.io/nusa-catalogue/card.html?1`, will be modified to `https://indonlp.github.io/nusa-catalogue/card.html?casa`. The `casa` name is listed in the right-most column of the metadata table